### PR TITLE
[Do not merge] draft for autolog

### DIFF
--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -20,8 +20,9 @@ import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
 from torch.autograd import Variable
-from tensorboardX import SummaryWriter
+# from tensorboardX import SummaryWriter
 
+mlflow.autolog()
 # Command-line arguments
 parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
 parser.add_argument(
@@ -39,7 +40,7 @@ parser.add_argument(
     help="input batch size for testing (default: 1000)",
 )
 parser.add_argument(
-    "--epochs", type=int, default=10, metavar="N", help="number of epochs to train (default: 10)"
+    "--epochs", type=int, default=2, metavar="N", help="number of epochs to train (default: 10)"
 )
 parser.add_argument(
     "--lr", type=float, default=0.01, metavar="LR", help="learning rate (default: 0.01)"
@@ -118,15 +119,15 @@ class Net(nn.Module):
         x = self.fc2(x)
         return F.log_softmax(x, dim=0)
 
-    def log_weights(self, step):
-        writer.add_histogram("weights/conv1/weight", model.conv1.weight.data, step)
-        writer.add_histogram("weights/conv1/bias", model.conv1.bias.data, step)
-        writer.add_histogram("weights/conv2/weight", model.conv2.weight.data, step)
-        writer.add_histogram("weights/conv2/bias", model.conv2.bias.data, step)
-        writer.add_histogram("weights/fc1/weight", model.fc1.weight.data, step)
-        writer.add_histogram("weights/fc1/bias", model.fc1.bias.data, step)
-        writer.add_histogram("weights/fc2/weight", model.fc2.weight.data, step)
-        writer.add_histogram("weights/fc2/bias", model.fc2.bias.data, step)
+    # def log_weights(self, step):
+    #     writer.add_histogram("weights/conv1/weight", model.conv1.weight.data, step)
+    #     writer.add_histogram("weights/conv1/bias", model.conv1.bias.data, step)
+    #     writer.add_histogram("weights/conv2/weight", model.conv2.weight.data, step)
+    #     writer.add_histogram("weights/conv2/bias", model.conv2.bias.data, step)
+    #     writer.add_histogram("weights/fc1/weight", model.fc1.weight.data, step)
+    #     writer.add_histogram("weights/fc1/bias", model.fc1.bias.data, step)
+    #     writer.add_histogram("weights/fc2/weight", model.fc2.weight.data, step)
+    #     writer.add_histogram("weights/fc2/bias", model.fc2.bias.data, step)
 
 
 model = Net()
@@ -135,7 +136,7 @@ if args.cuda:
 
 optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
 
-writer = None  # Will be used to write TensorBoard events
+# writer = None  # Will be used to write TensorBoard events
 
 
 def train(epoch):
@@ -160,8 +161,8 @@ def train(epoch):
                 )
             )
             step = epoch * len(train_loader) + batch_idx
-            log_scalar("train_loss", loss.data.item(), step)
-            model.log_weights(step)
+            # log_scalar("train_loss", loss.data.item(), step)
+            # model.log_weights(step)
 
 
 def test(epoch):
@@ -188,24 +189,24 @@ def test(epoch):
         )
     )
     step = (epoch + 1) * len(train_loader)
-    log_scalar("test_loss", test_loss, step)
-    log_scalar("test_accuracy", test_accuracy, step)
+    # log_scalar("test_loss", test_loss, step)
+    # log_scalar("test_accuracy", test_accuracy, step)
 
 
-def log_scalar(name, value, step):
-    """Log a scalar value to both MLflow and TensorBoard"""
-    writer.add_scalar(name, value, step)
-    mlflow.log_metric(name, value)
+# def log_scalar(name, value, step):
+#     """Log a scalar value to both MLflow and TensorBoard"""
+#     writer.add_scalar(name, value, step)
+#     mlflow.log_metric(name, value)
 
 
-with mlflow.start_run():
+with mlflow.start_run() as run1:
     # Log our parameters into mlflow
-    for key, value in vars(args).items():
-        mlflow.log_param(key, value)
+    # for key, value in vars(args).items():
+    #     mlflow.log_param(key, value)
 
     # Create a SummaryWriter to write TensorBoard events locally
     output_dir = dirpath = tempfile.mkdtemp()
-    writer = SummaryWriter(output_dir)
+    # writer = SummaryWriter(output_dir)
     print("Writing TensorBoard events locally to %s\n" % output_dir)
 
     # Perform the training
@@ -222,21 +223,23 @@ with mlflow.start_run():
     )
 
     # Log the model as an artifact of the MLflow run.
-    print("\nLogging the trained model as a run artifact...")
-    mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
-    print(
-        "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
-    )
+    # print("\nLogging the trained model as a run artifact...")
+    # mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
+    # print(
+    #     "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
+    # )
 
-    # Since the model was logged as an artifact, it can be loaded to make predictions
-    loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
+# Since the model was logged as an artifact, it can be loaded to make predictions
+# model_uri = "runs:/{}/model".format(run1.info.run_id)
+# loaded_model = mlflow.pytorch.load_model(model_uri)
+# # loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
 
-    # Extract a few examples from the test dataset to evaulate on
-    eval_data, eval_labels = next(iter(test_loader))
+# # Extract a few examples from the test dataset to evaulate on
+# eval_data, eval_labels = next(iter(test_loader))
 
-    # Make a few predictions
-    predictions = loaded_model(eval_data).data.max(1)[1]
-    template = 'Sample {} : Ground truth is "{}", model prediction is "{}"'
-    print("\nSample predictions")
-    for index in range(5):
-        print(template.format(index, eval_labels[index], predictions[index]))
+# # Make a few predictions
+# predictions = loaded_model(eval_data).data.max(1)[1]
+# template = 'Sample {} : Ground truth is "{}", model prediction is "{}"'
+# print("\nSample predictions")
+# for index in range(5):
+#     print(template.format(index, eval_labels[index], predictions[index]))

--- a/mlflow/tensorboardx_autologging.py
+++ b/mlflow/tensorboardx_autologging.py
@@ -16,12 +16,13 @@ from mlflow.utils.autologging_utils import (
 )
 from mlflow.utils.annotations import experimental
 from tensorboardX import SummaryWriter
+from mlflow.pytorch import FLAVOR_NAME
 
 _metric_queue = []
 _MAX_METRIC_QUEUE_SIZE = 500
 _thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 _metric_queue_lock = RLock()
-FLAVOR_NAME = "tensorboardX"
+# FLAVOR_NAME = "tensorboardX"
 
 
 def _add_to_queue(key, value, step, time, run_id):
@@ -120,24 +121,8 @@ def autolog():
         return original(self, arg1, arg2, arg3)
 
     non_managed = [
-        (SummaryWriter, "add_scalar", add_scalar),
-        # (EventFileWriter, "add_event", add_event),
-        # (EventFileWriterV2, "add_event", add_event),
-        # (FileWriter, "add_summary", add_summary),
-        # (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
-        # (tensorflow.estimator.Estimator, "export_savedmodel", export_saved_model),
+        (SummaryWriter, "add_scalar", add_scalar)
     ]
-
-    # Add compat.v1 Estimator patching for versions of tensfor that are 2.0+.
-    # if LooseVersion(tensorflow.__version__) >= LooseVersion("2.0.0"):
-    #     old_estimator_class = tensorflow.compat.v1.estimator.Estimator
-    #     v1_train = (old_estimator_class, "train", train)
-    #     v1_export_saved_model = (old_estimator_class, "export_saved_model", export_saved_model)
-    #     v1_export_savedmodel = (old_estimator_class, "export_savedmodel", export_saved_model)
-
-    #     managed.append(v1_train)
-    #     non_managed.append(v1_export_saved_model)
-    #     non_managed.append(v1_export_savedmodel)
 
     for p in non_managed:
         safe_patch(FLAVOR_NAME, *p)


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
